### PR TITLE
Service Client Seperation and Testing

### DIFF
--- a/src/main/java/com/example/spotifyexplorer/client/SpotifyAPIClient.java
+++ b/src/main/java/com/example/spotifyexplorer/client/SpotifyAPIClient.java
@@ -8,10 +8,14 @@ import org.springframework.web.client.RestTemplate;
 @Component
 public class SpotifyAPIClient {
 
-    private final RestTemplate restTemplate = new RestTemplate();
-
     @Value("${spotify.bearer-token}")
     private String bearerToken;
+
+    private final RestTemplate restTemplate;
+
+    public SpotifyAPIClient(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
 
     public String getNewAlbumRecommendations() {
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/example/spotifyexplorer/client/SpotifyAPIClient.java
+++ b/src/main/java/com/example/spotifyexplorer/client/SpotifyAPIClient.java
@@ -1,0 +1,31 @@
+package com.example.spotifyexplorer.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class SpotifyAPIClient {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${spotify.bearer-token}")
+    private String bearerToken;
+
+    public String getNewAlbumRecommendations() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(bearerToken);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<String> response = this.restTemplate.exchange(
+                "https://api.spotify.com/v1/browse/new-releases",
+                HttpMethod.GET,
+                entity,
+                String.class);
+
+        return response.getBody();
+    }
+}

--- a/src/main/java/com/example/spotifyexplorer/client/SpotifyAPIClient.java
+++ b/src/main/java/com/example/spotifyexplorer/client/SpotifyAPIClient.java
@@ -2,10 +2,10 @@ package com.example.spotifyexplorer.client;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
-@Service
+@Component
 public class SpotifyAPIClient {
 
     private final RestTemplate restTemplate = new RestTemplate();

--- a/src/main/java/com/example/spotifyexplorer/service/NewAlbumService.java
+++ b/src/main/java/com/example/spotifyexplorer/service/NewAlbumService.java
@@ -10,9 +10,16 @@ import java.util.List;
 @Service
 public class NewAlbumService {
 
+    private final SpotifyAPIClient spotifyAPIClient;
+
+    public NewAlbumService(SpotifyAPIClient spotifyAPIClient) {
+        this.spotifyAPIClient = spotifyAPIClient;
+    }
+
+
     public String getStringOutput() throws Exception {
 
-        String response = new SpotifyAPIClient().getNewAlbumRecommendations();
+        String response = spotifyAPIClient.getNewAlbumRecommendations();
 
         List<Album> albumAndArtists = new AlbumJsonTransformer().parseAlbums(response);
 

--- a/src/main/java/com/example/spotifyexplorer/service/NewAlbumService.java
+++ b/src/main/java/com/example/spotifyexplorer/service/NewAlbumService.java
@@ -1,46 +1,20 @@
 package com.example.spotifyexplorer.service;
 
+import com.example.spotifyexplorer.client.SpotifyAPIClient;
 import com.example.spotifyexplorer.models.Album;
 import com.example.spotifyexplorer.transformer.AlbumJsonTransformer;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.*;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
 
 @Service
 public class NewAlbumService {
-    public NewAlbumService(RestTemplate restTemplate) {
-        this.restTemplate = restTemplate;
-    }
-
-    private final RestTemplate restTemplate;
-
-    @Value("${spotify.bearer-token}")
-    private String bearerToken;
-
-    public String getNewAlbumRecommendations() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.setBearerAuth(bearerToken);
-
-        HttpEntity<String> entity = new HttpEntity<>(headers);
-
-        ResponseEntity<String> response = restTemplate.exchange(
-                "https://api.spotify.com/v1/browse/new-releases",
-                HttpMethod.GET,
-                entity,
-                String.class);
-
-        return response.getBody();
-    }
 
     public String getStringOutput() throws Exception {
 
-        String json = getNewAlbumRecommendations();
+        String response = new SpotifyAPIClient().getNewAlbumRecommendations();
 
-        List<Album> albumAndArtists = new AlbumJsonTransformer().parseAlbums(json);
+        List<Album> albumAndArtists = new AlbumJsonTransformer().parseAlbums(response);
 
         return "Here is new album recommendation: " + albumAndArtists.get(0).getName() +
                 " - " + albumAndArtists.get(0).getArtists().get(0).getName();

--- a/src/test/java/com/example/spotifyexplorer/resources/new_album_response.json
+++ b/src/test/java/com/example/spotifyexplorer/resources/new_album_response.json
@@ -1,0 +1,778 @@
+{
+  "albums" : {
+    "href" : "https://api.spotify.com/v1/browse/new-releases?country=GB&offset=0&limit=20",
+    "items" : [ {
+      "album_type" : "album",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/1XgFuvRd7r5g0h844A5ZUQ"
+        },
+        "href" : "https://api.spotify.com/v1/artists/1XgFuvRd7r5g0h844A5ZUQ",
+        "id" : "1XgFuvRd7r5g0h844A5ZUQ",
+        "name" : "Take That",
+        "type" : "artist",
+        "uri" : "spotify:artist:1XgFuvRd7r5g0h844A5ZUQ"
+      } ],
+      "available_markets" : [ "AE", "AM", "AU", "AZ", "BD", "BG", "BH", "BI", "BN", "BT", "BW", "CY", "DJ", "EE", "EG", "ET", "FI", "FJ", "FM", "GE", "GR", "HK", "ID", "IL", "IN", "IQ", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KR", "KW", "KZ", "LA", "LB", "LK", "LS", "LT", "LV", "LY", "MD", "MG", "MH", "MN", "MO", "MU", "MV", "MW", "MY", "MZ", "NA", "NP", "NR", "NZ", "OM", "PG", "PH", "PK", "PS", "PW", "QA", "RO", "RW", "SA", "SB", "SC", "SG", "SZ", "TH", "TJ", "TL", "TO", "TR", "TV", "TW", "TZ", "UA", "UG", "UZ", "VN", "VU", "WS", "ZA", "ZM", "ZW", "AD", "AL", "AO", "AT", "BA", "BE", "BJ", "CD", "CG", "CH", "CM", "CZ", "DE", "DK", "DZ", "ES", "FR", "GA", "GQ", "HR", "HU", "IT", "LI", "LU", "MA", "MC", "ME", "MK", "MT", "NE", "NG", "NL", "NO", "PL", "RS", "SE", "SI", "SK", "SM", "TD", "TN", "XK", "BF", "CI", "GB", "GH", "GM", "GN", "GW", "IE", "IS", "LR", "ML", "MR", "PT", "SL", "SN", "ST", "TG", "CV", "AR", "BR", "CL", "PY", "SR", "UY", "AG", "BB", "BO", "CW", "DM", "DO", "GD", "GY", "KN", "LC", "TT", "VC", "VE", "BS", "CA", "CO", "EC", "HT", "JM", "PA", "PE", "US", "BZ", "CR", "GT", "HN", "MX", "NI", "SV" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/4uWcWrnFw0c0cl6Z8Q0lPN"
+      },
+      "href" : "https://api.spotify.com/v1/albums/4uWcWrnFw0c0cl6Z8Q0lPN",
+      "id" : "4uWcWrnFw0c0cl6Z8Q0lPN",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b273b35cc183d781956d0ba771ba",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e02b35cc183d781956d0ba771ba",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d00004851b35cc183d781956d0ba771ba",
+        "width" : 64
+      } ],
+      "name" : "This Life",
+      "release_date" : "2023-11-24",
+      "release_date_precision" : "day",
+      "total_tracks" : 12,
+      "type" : "album",
+      "uri" : "spotify:album:4uWcWrnFw0c0cl6Z8Q0lPN"
+    }, {
+      "album_type" : "album",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/7gOJzXf9msdY8JUhMQypSH"
+        },
+        "href" : "https://api.spotify.com/v1/artists/7gOJzXf9msdY8JUhMQypSH",
+        "id" : "7gOJzXf9msdY8JUhMQypSH",
+        "name" : "M1onTheBeat",
+        "type" : "artist",
+        "uri" : "spotify:artist:7gOJzXf9msdY8JUhMQypSH"
+      } ],
+      "available_markets" : [ "AD", "AE", "AL", "AM", "AO", "AT", "AU", "AZ", "BA", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BT", "BW", "CD", "CG", "CH", "CI", "CM", "CV", "CY", "CZ", "DE", "DJ", "DK", "DZ", "EE", "EG", "ES", "ET", "FI", "FJ", "FM", "FR", "GA", "GB", "GE", "GH", "GM", "GN", "GQ", "GR", "GW", "HK", "HR", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KR", "KW", "KZ", "LA", "LB", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MY", "MZ", "NA", "NE", "NG", "NL", "NO", "NP", "NR", "NZ", "OM", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "ST", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TV", "TW", "TZ", "UA", "UG", "UZ", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW", "AR", "BR", "CL", "PY", "SR", "UY", "AG", "BB", "BO", "CW", "DM", "DO", "GD", "GY", "KN", "LC", "TT", "VC", "VE", "BS", "CA", "CO", "EC", "HT", "JM", "PA", "PE", "US", "BZ", "CR", "GT", "HN", "MX", "NI", "SV" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/2eNxE5vYk1YgZGQx6BT8UL"
+      },
+      "href" : "https://api.spotify.com/v1/albums/2eNxE5vYk1YgZGQx6BT8UL",
+      "id" : "2eNxE5vYk1YgZGQx6BT8UL",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b2733343f1042ecea58c0ad9b7f8",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e023343f1042ecea58c0ad9b7f8",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d000048513343f1042ecea58c0ad9b7f8",
+        "width" : 64
+      } ],
+      "name" : "M1onTheBeat The Mixtape",
+      "release_date" : "2023-11-24",
+      "release_date_precision" : "day",
+      "total_tracks" : 15,
+      "type" : "album",
+      "uri" : "spotify:album:2eNxE5vYk1YgZGQx6BT8UL"
+    }, {
+      "album_type" : "album",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/2BPwxhCvvcb8xDl8GWIjbh"
+        },
+        "href" : "https://api.spotify.com/v1/artists/2BPwxhCvvcb8xDl8GWIjbh",
+        "id" : "2BPwxhCvvcb8xDl8GWIjbh",
+        "name" : "Odeal",
+        "type" : "artist",
+        "uri" : "spotify:artist:2BPwxhCvvcb8xDl8GWIjbh"
+      } ],
+      "available_markets" : [ "AE", "AM", "AU", "AZ", "BD", "BG", "BH", "BI", "BN", "BT", "BW", "BY", "CY", "DJ", "EE", "EG", "ET", "FI", "FJ", "FM", "GE", "GR", "HK", "ID", "IL", "IN", "IQ", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KR", "KW", "KZ", "LA", "LB", "LK", "LS", "LT", "LV", "LY", "MD", "MG", "MH", "MN", "MO", "MU", "MV", "MW", "MY", "MZ", "NA", "NP", "NR", "NZ", "OM", "PG", "PH", "PK", "PS", "PW", "QA", "RO", "RW", "SA", "SB", "SC", "SG", "SZ", "TH", "TJ", "TL", "TO", "TR", "TV", "TW", "TZ", "UA", "UG", "UZ", "VN", "VU", "WS", "ZA", "ZM", "ZW", "AD", "AL", "AO", "AT", "BA", "BE", "BJ", "CD", "CG", "CH", "CM", "CZ", "DE", "DK", "DZ", "ES", "FR", "GA", "GQ", "HR", "HU", "IT", "LI", "LU", "MA", "MC", "ME", "MK", "MT", "NE", "NG", "NL", "NO", "PL", "RS", "SE", "SI", "SK", "SM", "TD", "TN", "XK", "BF", "CI", "GB", "GH", "GM", "GN", "GW", "IE", "IS", "LR", "ML", "MR", "PT", "SL", "SN", "ST", "TG", "CV", "AR", "BR", "CL", "PY", "SR", "UY", "AG", "BB", "BO", "CW", "DM", "DO", "GD", "GY", "KN", "LC", "TT", "VC", "VE", "BS", "CA", "CO", "EC", "HT", "JM", "PA", "PE", "US", "BZ", "CR", "GT", "HN", "MX", "NI", "SV" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/2Sz9KQ4T0nCCXBMDQ8TjFl"
+      },
+      "href" : "https://api.spotify.com/v1/albums/2Sz9KQ4T0nCCXBMDQ8TjFl",
+      "id" : "2Sz9KQ4T0nCCXBMDQ8TjFl",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b273b99bdc5b4126a09864f70aa9",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e02b99bdc5b4126a09864f70aa9",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d00004851b99bdc5b4126a09864f70aa9",
+        "width" : 64
+      } ],
+      "name" : "Thoughts I Never Said",
+      "release_date" : "2023-11-24",
+      "release_date_precision" : "day",
+      "total_tracks" : 9,
+      "type" : "album",
+      "uri" : "spotify:album:2Sz9KQ4T0nCCXBMDQ8TjFl"
+    }, {
+      "album_type" : "single",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/7w29UYBi0qsHi5RTcv3lmA"
+        },
+        "href" : "https://api.spotify.com/v1/artists/7w29UYBi0qsHi5RTcv3lmA",
+        "id" : "7w29UYBi0qsHi5RTcv3lmA",
+        "name" : "Björk",
+        "type" : "artist",
+        "uri" : "spotify:artist:7w29UYBi0qsHi5RTcv3lmA"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/7ltDVBr6mKbRvohxheJ9h1"
+        },
+        "href" : "https://api.spotify.com/v1/artists/7ltDVBr6mKbRvohxheJ9h1",
+        "id" : "7ltDVBr6mKbRvohxheJ9h1",
+        "name" : "ROSALÍA",
+        "type" : "artist",
+        "uri" : "spotify:artist:7ltDVBr6mKbRvohxheJ9h1"
+      } ],
+      "available_markets" : [ "AR", "AU", "AT", "BE", "BO", "BR", "BG", "CL", "CO", "CR", "CY", "CZ", "DK", "DO", "DE", "EC", "EE", "SV", "FI", "FR", "GR", "GT", "HN", "HK", "HU", "IS", "IE", "IT", "LV", "LT", "LU", "MY", "MT", "MX", "NL", "NZ", "NI", "NO", "PA", "PY", "PE", "PH", "PL", "PT", "SG", "SK", "ES", "SE", "CH", "TW", "TR", "UY", "GB", "AD", "LI", "MC", "ID", "JP", "TH", "VN", "RO", "IL", "ZA", "SA", "AE", "BH", "QA", "OM", "KW", "EG", "MA", "DZ", "TN", "LB", "JO", "PS", "IN", "BY", "KZ", "MD", "UA", "AL", "BA", "HR", "ME", "MK", "RS", "SI", "KR", "BD", "PK", "LK", "GH", "KE", "NG", "TZ", "UG", "AG", "AM", "BS", "BB", "BZ", "BT", "BW", "BF", "CV", "CW", "DM", "FJ", "GM", "GE", "GD", "GW", "GY", "HT", "JM", "KI", "LS", "LR", "MW", "MV", "ML", "MH", "FM", "NA", "NR", "NE", "PW", "PG", "WS", "SM", "ST", "SN", "SC", "SL", "SB", "KN", "LC", "VC", "SR", "TL", "TO", "TT", "TV", "VU", "AZ", "BN", "BI", "KH", "CM", "TD", "KM", "GQ", "SZ", "GA", "GN", "KG", "LA", "MO", "MR", "MN", "NP", "RW", "TG", "UZ", "ZW", "BJ", "MG", "MU", "MZ", "AO", "CI", "DJ", "ZM", "CD", "CG", "IQ", "LY", "TJ", "VE", "ET", "XK" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/4JQVXceKAkVXlkCxh1CY0f"
+      },
+      "href" : "https://api.spotify.com/v1/albums/4JQVXceKAkVXlkCxh1CY0f",
+      "id" : "4JQVXceKAkVXlkCxh1CY0f",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b273aa9f6af16548a0b0b106d282",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e02aa9f6af16548a0b0b106d282",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d00004851aa9f6af16548a0b0b106d282",
+        "width" : 64
+      } ],
+      "name" : "Oral",
+      "release_date" : "2023-11-21",
+      "release_date_precision" : "day",
+      "total_tracks" : 1,
+      "type" : "album",
+      "uri" : "spotify:album:4JQVXceKAkVXlkCxh1CY0f"
+    }, {
+      "album_type" : "single",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/2Lr6UcfZWL1Ur5spOaduOb"
+        },
+        "href" : "https://api.spotify.com/v1/artists/2Lr6UcfZWL1Ur5spOaduOb",
+        "id" : "2Lr6UcfZWL1Ur5spOaduOb",
+        "name" : "Ryder",
+        "type" : "artist",
+        "uri" : "spotify:artist:2Lr6UcfZWL1Ur5spOaduOb"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/2p1fiYHYiXz9qi0JJyxBzN"
+        },
+        "href" : "https://api.spotify.com/v1/artists/2p1fiYHYiXz9qi0JJyxBzN",
+        "id" : "2p1fiYHYiXz9qi0JJyxBzN",
+        "name" : "Skepta",
+        "type" : "artist",
+        "uri" : "spotify:artist:2p1fiYHYiXz9qi0JJyxBzN"
+      } ],
+      "available_markets" : [ "AE", "AM", "AU", "AZ", "BD", "BG", "BH", "BI", "BN", "BT", "BW", "BY", "CY", "DJ", "EE", "EG", "ET", "FI", "FJ", "FM", "GE", "GR", "HK", "ID", "IL", "IN", "IQ", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KR", "KW", "KZ", "LA", "LB", "LK", "LS", "LT", "LV", "LY", "MD", "MG", "MH", "MN", "MO", "MU", "MV", "MW", "MY", "MZ", "NA", "NP", "NR", "NZ", "OM", "PG", "PH", "PK", "PS", "PW", "QA", "RO", "RW", "SA", "SB", "SC", "SG", "SZ", "TH", "TJ", "TL", "TO", "TR", "TV", "TW", "TZ", "UA", "UG", "UZ", "VN", "VU", "WS", "ZA", "ZM", "ZW", "AD", "AL", "AO", "AT", "BA", "BE", "BJ", "CD", "CG", "CH", "CM", "CZ", "DE", "DK", "DZ", "ES", "FR", "GA", "GQ", "HR", "HU", "IT", "LI", "LU", "MA", "MC", "ME", "MK", "MT", "NE", "NG", "NL", "NO", "PL", "RS", "SE", "SI", "SK", "SM", "TD", "TN", "XK", "BF", "CI", "GB", "GH", "GM", "GN", "GW", "IE", "IS", "LR", "ML", "MR", "PT", "SL", "SN", "ST", "TG", "CV", "AR", "BR", "CL", "PY", "SR", "UY", "AG", "BB", "BO", "CW", "DM", "DO", "GD", "GY", "KN", "LC", "TT", "VC", "VE", "BS", "CA", "CO", "EC", "HT", "JM", "PA", "PE", "US", "BZ", "CR", "GT", "HN", "MX", "NI", "SV" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/7B8hgK92g5E2WnKkKjEzRp"
+      },
+      "href" : "https://api.spotify.com/v1/albums/7B8hgK92g5E2WnKkKjEzRp",
+      "id" : "7B8hgK92g5E2WnKkKjEzRp",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b273354d6c4358eb2c97be16526b",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e02354d6c4358eb2c97be16526b",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d00004851354d6c4358eb2c97be16526b",
+        "width" : 64
+      } ],
+      "name" : "48 Hours",
+      "release_date" : "2023-11-24",
+      "release_date_precision" : "day",
+      "total_tracks" : 5,
+      "type" : "album",
+      "uri" : "spotify:album:7B8hgK92g5E2WnKkKjEzRp"
+    }, {
+      "album_type" : "album",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/3TVXtAsR1Inumwj472S9r4"
+        },
+        "href" : "https://api.spotify.com/v1/artists/3TVXtAsR1Inumwj472S9r4",
+        "id" : "3TVXtAsR1Inumwj472S9r4",
+        "name" : "Drake",
+        "type" : "artist",
+        "uri" : "spotify:artist:3TVXtAsR1Inumwj472S9r4"
+      } ],
+      "available_markets" : [ "AR", "AU", "AT", "BE", "BO", "BR", "BG", "CA", "CL", "CO", "CR", "CY", "CZ", "DK", "DO", "DE", "EC", "EE", "SV", "FI", "FR", "GR", "GT", "HN", "HK", "HU", "IS", "IE", "IT", "LV", "LT", "LU", "MY", "MT", "MX", "NL", "NZ", "NI", "NO", "PA", "PY", "PE", "PH", "PL", "PT", "SG", "SK", "ES", "SE", "CH", "TW", "TR", "UY", "US", "GB", "AD", "LI", "MC", "ID", "JP", "TH", "VN", "RO", "IL", "ZA", "SA", "AE", "BH", "QA", "OM", "KW", "EG", "MA", "DZ", "TN", "LB", "JO", "PS", "IN", "KZ", "MD", "UA", "AL", "BA", "HR", "ME", "MK", "RS", "SI", "KR", "BD", "PK", "LK", "GH", "KE", "NG", "TZ", "UG", "AG", "AM", "BS", "BB", "BZ", "BT", "BW", "BF", "CV", "CW", "DM", "FJ", "GM", "GE", "GD", "GW", "GY", "HT", "JM", "KI", "LS", "LR", "MW", "MV", "ML", "MH", "FM", "NA", "NR", "NE", "PW", "PG", "WS", "SM", "ST", "SN", "SC", "SL", "SB", "KN", "LC", "VC", "SR", "TL", "TO", "TT", "TV", "VU", "AZ", "BN", "BI", "KH", "CM", "TD", "KM", "GQ", "SZ", "GA", "GN", "KG", "LA", "MO", "MR", "MN", "NP", "RW", "TG", "UZ", "ZW", "BJ", "MG", "MU", "MZ", "AO", "CI", "DJ", "ZM", "CD", "CG", "IQ", "LY", "TJ", "VE", "ET", "XK" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/20llijrPaOy2qVivkSXuRB"
+      },
+      "href" : "https://api.spotify.com/v1/albums/20llijrPaOy2qVivkSXuRB",
+      "id" : "20llijrPaOy2qVivkSXuRB",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b273d329886e89e51420478f4751",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e02d329886e89e51420478f4751",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d00004851d329886e89e51420478f4751",
+        "width" : 64
+      } ],
+      "name" : "For All The Dogs Scary Hours Edition",
+      "release_date" : "2023-11-17",
+      "release_date_precision" : "day",
+      "total_tracks" : 29,
+      "type" : "album",
+      "uri" : "spotify:album:20llijrPaOy2qVivkSXuRB"
+    }, {
+      "album_type" : "single",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/4XC335ouK6pXyq4QiIb8bP"
+        },
+        "href" : "https://api.spotify.com/v1/artists/4XC335ouK6pXyq4QiIb8bP",
+        "id" : "4XC335ouK6pXyq4QiIb8bP",
+        "name" : "Eliza Rose",
+        "type" : "artist",
+        "uri" : "spotify:artist:4XC335ouK6pXyq4QiIb8bP"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/7CajNmpbOovFoOoasH2HaY"
+        },
+        "href" : "https://api.spotify.com/v1/artists/7CajNmpbOovFoOoasH2HaY",
+        "id" : "7CajNmpbOovFoOoasH2HaY",
+        "name" : "Calvin Harris",
+        "type" : "artist",
+        "uri" : "spotify:artist:7CajNmpbOovFoOoasH2HaY"
+      } ],
+      "available_markets" : [ "AR", "AU", "AT", "BE", "BO", "BR", "BG", "CA", "CL", "CO", "CR", "CY", "CZ", "DK", "DO", "DE", "EC", "EE", "SV", "FI", "FR", "GR", "GT", "HN", "HK", "HU", "IS", "IE", "IT", "LV", "LT", "LU", "MY", "MT", "MX", "NL", "NZ", "NI", "NO", "PA", "PY", "PE", "PH", "PL", "PT", "SG", "SK", "ES", "SE", "CH", "TW", "TR", "UY", "US", "GB", "AD", "LI", "MC", "ID", "JP", "TH", "VN", "RO", "IL", "ZA", "SA", "AE", "BH", "QA", "OM", "KW", "EG", "MA", "DZ", "TN", "LB", "JO", "PS", "IN", "BY", "KZ", "MD", "UA", "AL", "BA", "HR", "ME", "MK", "RS", "SI", "KR", "BD", "PK", "LK", "GH", "KE", "NG", "TZ", "UG", "AG", "AM", "BS", "BB", "BZ", "BT", "BW", "BF", "CV", "CW", "DM", "FJ", "GM", "GE", "GD", "GW", "GY", "HT", "JM", "KI", "LS", "LR", "MW", "MV", "ML", "MH", "FM", "NA", "NR", "NE", "PW", "PG", "WS", "SM", "ST", "SN", "SC", "SL", "SB", "KN", "LC", "VC", "SR", "TL", "TO", "TT", "TV", "VU", "AZ", "BN", "BI", "KH", "CM", "TD", "KM", "GQ", "SZ", "GA", "GN", "KG", "LA", "MO", "MR", "MN", "NP", "RW", "TG", "UZ", "ZW", "BJ", "MG", "MU", "MZ", "AO", "CI", "DJ", "ZM", "CD", "CG", "IQ", "LY", "TJ", "VE", "ET", "XK" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/5EcypjAXyzxlrF5AKCNg9K"
+      },
+      "href" : "https://api.spotify.com/v1/albums/5EcypjAXyzxlrF5AKCNg9K",
+      "id" : "5EcypjAXyzxlrF5AKCNg9K",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b273535aaa51352955a479bc5371",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e02535aaa51352955a479bc5371",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d00004851535aaa51352955a479bc5371",
+        "width" : 64
+      } ],
+      "name" : "Body Moving",
+      "release_date" : "2023-11-17",
+      "release_date_precision" : "day",
+      "total_tracks" : 1,
+      "type" : "album",
+      "uri" : "spotify:album:5EcypjAXyzxlrF5AKCNg9K"
+    }, {
+      "album_type" : "single",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/5BRAUN0yN8557PLRZIr02W"
+        },
+        "href" : "https://api.spotify.com/v1/artists/5BRAUN0yN8557PLRZIr02W",
+        "id" : "5BRAUN0yN8557PLRZIr02W",
+        "name" : "Ezra Collective",
+        "type" : "artist",
+        "uri" : "spotify:artist:5BRAUN0yN8557PLRZIr02W"
+      } ],
+      "available_markets" : [ "AU", "NZ" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/449dMkw6EUBuQRAXbBFinU"
+      },
+      "href" : "https://api.spotify.com/v1/albums/449dMkw6EUBuQRAXbBFinU",
+      "id" : "449dMkw6EUBuQRAXbBFinU",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b2738facfcc39a2371c05d6f1592",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e028facfcc39a2371c05d6f1592",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d000048518facfcc39a2371c05d6f1592",
+        "width" : 64
+      } ],
+      "name" : "God Rest Ye Merry Gentlemen (Spotify Singles Holiday)",
+      "release_date" : "2023-11-14",
+      "release_date_precision" : "day",
+      "total_tracks" : 1,
+      "type" : "album",
+      "uri" : "spotify:album:449dMkw6EUBuQRAXbBFinU"
+    }, {
+      "album_type" : "single",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/7ANeFdhioipksT9lqg0Ay6"
+        },
+        "href" : "https://api.spotify.com/v1/artists/7ANeFdhioipksT9lqg0Ay6",
+        "id" : "7ANeFdhioipksT9lqg0Ay6",
+        "name" : "Ego Ella May",
+        "type" : "artist",
+        "uri" : "spotify:artist:7ANeFdhioipksT9lqg0Ay6"
+      } ],
+      "available_markets" : [ "AR", "AU", "AT", "BE", "BO", "BR", "BG", "CA", "CL", "CO", "CR", "CY", "CZ", "DK", "DO", "DE", "EC", "EE", "SV", "FI", "FR", "GR", "GT", "HN", "HK", "HU", "IS", "IE", "IT", "LV", "LT", "LU", "MY", "MT", "MX", "NL", "NZ", "NI", "NO", "PA", "PY", "PE", "PH", "PL", "PT", "SG", "SK", "ES", "SE", "CH", "TW", "TR", "UY", "US", "GB", "AD", "LI", "MC", "ID", "JP", "TH", "VN", "RO", "IL", "ZA", "SA", "AE", "BH", "QA", "OM", "KW", "EG", "MA", "DZ", "TN", "LB", "JO", "PS", "IN", "BY", "KZ", "MD", "UA", "AL", "BA", "HR", "ME", "MK", "RS", "SI", "KR", "BD", "PK", "LK", "GH", "KE", "NG", "TZ", "UG", "AG", "AM", "BS", "BB", "BZ", "BT", "BW", "BF", "CV", "CW", "DM", "FJ", "GM", "GE", "GD", "GW", "GY", "HT", "JM", "KI", "LS", "LR", "MW", "MV", "ML", "MH", "FM", "NA", "NR", "NE", "PW", "PG", "WS", "SM", "ST", "SN", "SC", "SL", "SB", "KN", "LC", "VC", "SR", "TL", "TO", "TT", "TV", "VU", "AZ", "BN", "BI", "KH", "CM", "TD", "KM", "GQ", "SZ", "GA", "GN", "KG", "LA", "MO", "MR", "MN", "NP", "RW", "TG", "UZ", "ZW", "BJ", "MG", "MU", "MZ", "AO", "CI", "DJ", "ZM", "CD", "CG", "IQ", "LY", "TJ", "VE", "ET", "XK" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/1mN1K7R6kn8FqBP2OY613q"
+      },
+      "href" : "https://api.spotify.com/v1/albums/1mN1K7R6kn8FqBP2OY613q",
+      "id" : "1mN1K7R6kn8FqBP2OY613q",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b27330d575a5e6ae21343fa26ab3",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e0230d575a5e6ae21343fa26ab3",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d0000485130d575a5e6ae21343fa26ab3",
+        "width" : 64
+      } ],
+      "name" : "FIELDNOTES PT III",
+      "release_date" : "2023-11-15",
+      "release_date_precision" : "day",
+      "total_tracks" : 4,
+      "type" : "album",
+      "uri" : "spotify:album:1mN1K7R6kn8FqBP2OY613q"
+    }, {
+      "album_type" : "album",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/7sfgqEdoeBTjd8lQsPT3Cy"
+        },
+        "href" : "https://api.spotify.com/v1/artists/7sfgqEdoeBTjd8lQsPT3Cy",
+        "id" : "7sfgqEdoeBTjd8lQsPT3Cy",
+        "name" : "Emeli Sandé",
+        "type" : "artist",
+        "uri" : "spotify:artist:7sfgqEdoeBTjd8lQsPT3Cy"
+      } ],
+      "available_markets" : [ "AR", "AU", "AT", "BE", "BO", "BR", "BG", "CA", "CL", "CO", "CR", "CY", "CZ", "DK", "DO", "DE", "EC", "EE", "SV", "FI", "FR", "GR", "GT", "HN", "HK", "HU", "IS", "IE", "IT", "LV", "LT", "LU", "MY", "MT", "MX", "NL", "NZ", "NI", "NO", "PA", "PY", "PE", "PH", "PL", "PT", "SG", "SK", "ES", "SE", "CH", "TW", "TR", "UY", "US", "GB", "AD", "LI", "MC", "ID", "JP", "TH", "VN", "RO", "IL", "ZA", "SA", "AE", "BH", "QA", "OM", "KW", "EG", "MA", "DZ", "TN", "LB", "JO", "PS", "IN", "BY", "KZ", "MD", "UA", "AL", "BA", "HR", "ME", "MK", "RS", "SI", "KR", "BD", "PK", "LK", "GH", "KE", "NG", "TZ", "UG", "AG", "AM", "BS", "BB", "BZ", "BT", "BW", "BF", "CV", "CW", "DM", "FJ", "GM", "GE", "GD", "GW", "GY", "HT", "JM", "KI", "LS", "LR", "MW", "MV", "ML", "MH", "FM", "NA", "NR", "NE", "PW", "PG", "WS", "SM", "ST", "SN", "SC", "SL", "SB", "KN", "LC", "VC", "SR", "TL", "TO", "TT", "TV", "VU", "AZ", "BN", "BI", "KH", "CM", "TD", "KM", "GQ", "SZ", "GA", "GN", "KG", "LA", "MO", "MR", "MN", "NP", "RW", "TG", "UZ", "ZW", "BJ", "MG", "MU", "MZ", "AO", "CI", "DJ", "ZM", "CD", "CG", "IQ", "LY", "TJ", "VE", "ET", "XK" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/2aCBNEaJ7hmfe64QWCaGIG"
+      },
+      "href" : "https://api.spotify.com/v1/albums/2aCBNEaJ7hmfe64QWCaGIG",
+      "id" : "2aCBNEaJ7hmfe64QWCaGIG",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b273f6593c9880d4f7f7a67dff5c",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e02f6593c9880d4f7f7a67dff5c",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d00004851f6593c9880d4f7f7a67dff5c",
+        "width" : 64
+      } ],
+      "name" : "How Were We To Know",
+      "release_date" : "2023-11-17",
+      "release_date_precision" : "day",
+      "total_tracks" : 11,
+      "type" : "album",
+      "uri" : "spotify:album:2aCBNEaJ7hmfe64QWCaGIG"
+    }, {
+      "album_type" : "single",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/07MX7XJsNTn8JlgEcbZ7Fd"
+        },
+        "href" : "https://api.spotify.com/v1/artists/07MX7XJsNTn8JlgEcbZ7Fd",
+        "id" : "07MX7XJsNTn8JlgEcbZ7Fd",
+        "name" : "Midas the Jagaban",
+        "type" : "artist",
+        "uri" : "spotify:artist:07MX7XJsNTn8JlgEcbZ7Fd"
+      } ],
+      "available_markets" : [ "AR", "AU", "AT", "BE", "BO", "BR", "BG", "CA", "CL", "CO", "CR", "CY", "CZ", "DK", "DO", "DE", "EC", "EE", "SV", "FI", "FR", "GR", "GT", "HN", "HK", "HU", "IS", "IE", "IT", "LV", "LT", "LU", "MY", "MT", "MX", "NL", "NZ", "NI", "NO", "PA", "PY", "PE", "PH", "PL", "PT", "SG", "SK", "ES", "SE", "CH", "TW", "TR", "UY", "US", "GB", "AD", "LI", "MC", "ID", "JP", "TH", "VN", "RO", "IL", "ZA", "SA", "AE", "BH", "QA", "OM", "KW", "EG", "MA", "DZ", "TN", "LB", "JO", "PS", "IN", "BY", "KZ", "MD", "UA", "AL", "BA", "HR", "ME", "MK", "RS", "SI", "KR", "BD", "PK", "LK", "GH", "KE", "NG", "TZ", "UG", "AG", "AM", "BS", "BB", "BZ", "BT", "BW", "BF", "CV", "CW", "DM", "FJ", "GM", "GE", "GD", "GW", "GY", "HT", "JM", "KI", "LS", "LR", "MW", "MV", "ML", "MH", "FM", "NA", "NR", "NE", "PW", "PG", "WS", "SM", "ST", "SN", "SC", "SL", "SB", "KN", "LC", "VC", "SR", "TL", "TO", "TT", "TV", "VU", "AZ", "BN", "BI", "KH", "CM", "TD", "KM", "GQ", "SZ", "GA", "GN", "KG", "LA", "MO", "MR", "MN", "NP", "RW", "TG", "UZ", "ZW", "BJ", "MG", "MU", "MZ", "AO", "CI", "DJ", "ZM", "CD", "CG", "IQ", "LY", "TJ", "VE", "ET", "XK" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/5RUzZy0wkLuPDeKM28GPtZ"
+      },
+      "href" : "https://api.spotify.com/v1/albums/5RUzZy0wkLuPDeKM28GPtZ",
+      "id" : "5RUzZy0wkLuPDeKM28GPtZ",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b27346e2804880e6d0825862a93a",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e0246e2804880e6d0825862a93a",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d0000485146e2804880e6d0825862a93a",
+        "width" : 64
+      } ],
+      "name" : "Midas Touch EP Vol 2: Return Of The Mask",
+      "release_date" : "2023-11-17",
+      "release_date_precision" : "day",
+      "total_tracks" : 7,
+      "type" : "album",
+      "uri" : "spotify:album:5RUzZy0wkLuPDeKM28GPtZ"
+    }, {
+      "album_type" : "single",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/6M2wZ9GZgrQXHCFfjv46we"
+        },
+        "href" : "https://api.spotify.com/v1/artists/6M2wZ9GZgrQXHCFfjv46we",
+        "id" : "6M2wZ9GZgrQXHCFfjv46we",
+        "name" : "Dua Lipa",
+        "type" : "artist",
+        "uri" : "spotify:artist:6M2wZ9GZgrQXHCFfjv46we"
+      } ],
+      "available_markets" : [ "AR", "AU", "BE", "BO", "BR", "BG", "CA", "CL", "CO", "CR", "CY", "CZ", "DK", "DO", "EC", "EE", "SV", "FI", "FR", "GR", "GT", "HN", "HK", "HU", "IS", "IE", "IT", "LV", "LT", "LU", "MY", "MT", "MX", "NL", "NZ", "NI", "NO", "PA", "PY", "PE", "PH", "PL", "PT", "SG", "SK", "ES", "SE", "TW", "TR", "UY", "US", "GB", "AD", "LI", "MC", "ID", "JP", "TH", "VN", "RO", "IL", "ZA", "SA", "AE", "BH", "QA", "OM", "KW", "EG", "MA", "DZ", "TN", "LB", "JO", "PS", "IN", "KZ", "MD", "UA", "AL", "BA", "HR", "ME", "MK", "RS", "SI", "KR", "BD", "PK", "LK", "GH", "KE", "NG", "TZ", "UG", "AG", "AM", "BS", "BB", "BZ", "BT", "BW", "BF", "CV", "CW", "DM", "FJ", "GM", "GE", "GD", "GW", "GY", "HT", "JM", "KI", "LS", "LR", "MW", "MV", "ML", "MH", "FM", "NA", "NR", "NE", "PW", "PG", "WS", "SM", "ST", "SN", "SC", "SL", "SB", "KN", "LC", "VC", "SR", "TL", "TO", "TT", "TV", "VU", "AZ", "BN", "BI", "KH", "CM", "TD", "KM", "GQ", "SZ", "GA", "GN", "KG", "LA", "MO", "MR", "MN", "NP", "RW", "TG", "UZ", "ZW", "BJ", "MG", "MU", "MZ", "AO", "CI", "DJ", "ZM", "CD", "CG", "IQ", "LY", "TJ", "VE", "ET", "XK" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/5pTaRVLwZOFObIbRBubmeb"
+      },
+      "href" : "https://api.spotify.com/v1/albums/5pTaRVLwZOFObIbRBubmeb",
+      "id" : "5pTaRVLwZOFObIbRBubmeb",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b273001d5706fddc72561f6488af",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e02001d5706fddc72561f6488af",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d00004851001d5706fddc72561f6488af",
+        "width" : 64
+      } ],
+      "name" : "Houdini",
+      "release_date" : "2023-11-09",
+      "release_date_precision" : "day",
+      "total_tracks" : 1,
+      "type" : "album",
+      "uri" : "spotify:album:5pTaRVLwZOFObIbRBubmeb"
+    }, {
+      "album_type" : "album",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/3jNkaOXasoc7RsxdchvEVq"
+        },
+        "href" : "https://api.spotify.com/v1/artists/3jNkaOXasoc7RsxdchvEVq",
+        "id" : "3jNkaOXasoc7RsxdchvEVq",
+        "name" : "Chase & Status",
+        "type" : "artist",
+        "uri" : "spotify:artist:3jNkaOXasoc7RsxdchvEVq"
+      } ],
+      "available_markets" : [ "AR", "AU", "AT", "BE", "BO", "BR", "BG", "CA", "CL", "CO", "CR", "CY", "CZ", "DK", "DO", "DE", "EC", "EE", "SV", "FI", "FR", "GR", "GT", "HN", "HK", "HU", "IS", "IE", "IT", "LV", "LT", "LU", "MY", "MT", "MX", "NL", "NZ", "NI", "NO", "PA", "PY", "PE", "PH", "PL", "PT", "SG", "SK", "ES", "SE", "CH", "TW", "TR", "UY", "US", "GB", "AD", "LI", "MC", "ID", "JP", "TH", "VN", "RO", "IL", "ZA", "SA", "AE", "BH", "QA", "OM", "KW", "EG", "MA", "DZ", "TN", "LB", "JO", "PS", "IN", "KZ", "MD", "UA", "AL", "BA", "HR", "ME", "MK", "RS", "SI", "KR", "BD", "PK", "LK", "GH", "KE", "NG", "TZ", "UG", "AG", "AM", "BS", "BB", "BZ", "BT", "BW", "BF", "CV", "CW", "DM", "FJ", "GM", "GE", "GD", "GW", "GY", "HT", "JM", "KI", "LS", "LR", "MW", "MV", "ML", "MH", "FM", "NA", "NR", "NE", "PW", "PG", "WS", "SM", "ST", "SN", "SC", "SL", "SB", "KN", "LC", "VC", "SR", "TL", "TO", "TT", "TV", "VU", "AZ", "BN", "BI", "KH", "CM", "TD", "KM", "GQ", "SZ", "GA", "GN", "KG", "LA", "MO", "MR", "MN", "NP", "RW", "TG", "UZ", "ZW", "BJ", "MG", "MU", "MZ", "AO", "CI", "DJ", "ZM", "CD", "CG", "IQ", "LY", "TJ", "VE", "ET", "XK" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/4SjzjaFsXvXiS7quZFzYEl"
+      },
+      "href" : "https://api.spotify.com/v1/albums/4SjzjaFsXvXiS7quZFzYEl",
+      "id" : "4SjzjaFsXvXiS7quZFzYEl",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b2738a7fdf2de701f3ea4cfacfc1",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e028a7fdf2de701f3ea4cfacfc1",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d000048518a7fdf2de701f3ea4cfacfc1",
+        "width" : 64
+      } ],
+      "name" : "2 RUFF, Vol. 1",
+      "release_date" : "2023-11-10",
+      "release_date_precision" : "day",
+      "total_tracks" : 10,
+      "type" : "album",
+      "uri" : "spotify:album:4SjzjaFsXvXiS7quZFzYEl"
+    }, {
+      "album_type" : "album",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/78rUTD7y6Cy67W1RVzYs7t"
+        },
+        "href" : "https://api.spotify.com/v1/artists/78rUTD7y6Cy67W1RVzYs7t",
+        "id" : "78rUTD7y6Cy67W1RVzYs7t",
+        "name" : "PinkPantheress",
+        "type" : "artist",
+        "uri" : "spotify:artist:78rUTD7y6Cy67W1RVzYs7t"
+      } ],
+      "available_markets" : [ "AR", "AU", "AT", "BE", "BO", "BR", "BG", "CA", "CL", "CO", "CR", "CY", "CZ", "DK", "DO", "DE", "EC", "EE", "SV", "FI", "FR", "GR", "GT", "HN", "HK", "HU", "IS", "IE", "IT", "LV", "LT", "LU", "MY", "MT", "MX", "NL", "NZ", "NI", "NO", "PA", "PY", "PE", "PH", "PL", "PT", "SG", "SK", "ES", "SE", "CH", "TW", "TR", "UY", "US", "GB", "AD", "LI", "MC", "ID", "JP", "TH", "VN", "RO", "IL", "ZA", "SA", "AE", "BH", "QA", "OM", "KW", "EG", "MA", "DZ", "TN", "LB", "JO", "PS", "IN", "KZ", "MD", "UA", "AL", "BA", "HR", "ME", "MK", "RS", "SI", "KR", "BD", "PK", "LK", "GH", "KE", "NG", "TZ", "UG", "AG", "AM", "BS", "BB", "BZ", "BT", "BW", "BF", "CV", "CW", "DM", "FJ", "GM", "GE", "GD", "GW", "GY", "HT", "JM", "KI", "LS", "LR", "MW", "MV", "ML", "MH", "FM", "NA", "NR", "NE", "PW", "PG", "WS", "SM", "ST", "SN", "SC", "SL", "SB", "KN", "LC", "VC", "SR", "TL", "TO", "TT", "TV", "VU", "AZ", "BN", "BI", "KH", "CM", "TD", "KM", "GQ", "SZ", "GA", "GN", "KG", "LA", "MO", "MR", "MN", "NP", "RW", "TG", "UZ", "ZW", "BJ", "MG", "MU", "MZ", "AO", "CI", "DJ", "ZM", "CD", "CG", "IQ", "LY", "TJ", "VE", "ET", "XK" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/2pOEFqvfxp5uUQ8vQEmVA0"
+      },
+      "href" : "https://api.spotify.com/v1/albums/2pOEFqvfxp5uUQ8vQEmVA0",
+      "id" : "2pOEFqvfxp5uUQ8vQEmVA0",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b27312e36c27d935e955b44c6581",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e0212e36c27d935e955b44c6581",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d0000485112e36c27d935e955b44c6581",
+        "width" : 64
+      } ],
+      "name" : "Heaven knows",
+      "release_date" : "2023-11-10",
+      "release_date_precision" : "day",
+      "total_tracks" : 13,
+      "type" : "album",
+      "uri" : "spotify:album:2pOEFqvfxp5uUQ8vQEmVA0"
+    }, {
+      "album_type" : "album",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/2tIP7SsRs7vjIcLrU85W8J"
+        },
+        "href" : "https://api.spotify.com/v1/artists/2tIP7SsRs7vjIcLrU85W8J",
+        "id" : "2tIP7SsRs7vjIcLrU85W8J",
+        "name" : "The Kid LAROI",
+        "type" : "artist",
+        "uri" : "spotify:artist:2tIP7SsRs7vjIcLrU85W8J"
+      } ],
+      "available_markets" : [ "AR", "AU", "AT", "BE", "BO", "BR", "BG", "CA", "CL", "CO", "CR", "CY", "CZ", "DK", "DO", "DE", "EC", "EE", "SV", "FI", "FR", "GR", "GT", "HN", "HK", "HU", "IS", "IE", "IT", "LV", "LT", "LU", "MY", "MT", "MX", "NL", "NZ", "NI", "NO", "PA", "PY", "PE", "PH", "PL", "PT", "SG", "SK", "ES", "SE", "CH", "TW", "TR", "UY", "US", "GB", "AD", "LI", "MC", "ID", "JP", "TH", "VN", "RO", "IL", "ZA", "SA", "AE", "BH", "QA", "OM", "KW", "EG", "MA", "DZ", "TN", "LB", "JO", "PS", "IN", "BY", "KZ", "MD", "UA", "AL", "BA", "HR", "ME", "MK", "RS", "SI", "KR", "BD", "PK", "LK", "GH", "KE", "NG", "TZ", "UG", "AG", "AM", "BS", "BB", "BZ", "BT", "BW", "BF", "CV", "CW", "DM", "FJ", "GM", "GE", "GD", "GW", "GY", "HT", "JM", "KI", "LS", "LR", "MW", "MV", "ML", "MH", "FM", "NA", "NR", "NE", "PW", "PG", "WS", "SM", "ST", "SN", "SC", "SL", "SB", "KN", "LC", "VC", "SR", "TL", "TO", "TT", "TV", "VU", "AZ", "BN", "BI", "KH", "CM", "TD", "KM", "GQ", "SZ", "GA", "GN", "KG", "LA", "MO", "MR", "MN", "NP", "RW", "TG", "UZ", "ZW", "BJ", "MG", "MU", "MZ", "AO", "CI", "DJ", "ZM", "CD", "CG", "IQ", "LY", "TJ", "VE", "ET", "XK" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/63IolVUykZCHMlu2zu9jHS"
+      },
+      "href" : "https://api.spotify.com/v1/albums/63IolVUykZCHMlu2zu9jHS",
+      "id" : "63IolVUykZCHMlu2zu9jHS",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b2732abb30c6296964d5d07458c2",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e022abb30c6296964d5d07458c2",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d000048512abb30c6296964d5d07458c2",
+        "width" : 64
+      } ],
+      "name" : "THE FIRST TIME",
+      "release_date" : "2023-11-10",
+      "release_date_precision" : "day",
+      "total_tracks" : 20,
+      "type" : "album",
+      "uri" : "spotify:album:63IolVUykZCHMlu2zu9jHS"
+    }, {
+      "album_type" : "single",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/4S68J6bchvHhqHO1Kp8W9X"
+        },
+        "href" : "https://api.spotify.com/v1/artists/4S68J6bchvHhqHO1Kp8W9X",
+        "id" : "4S68J6bchvHhqHO1Kp8W9X",
+        "name" : "Tamera",
+        "type" : "artist",
+        "uri" : "spotify:artist:4S68J6bchvHhqHO1Kp8W9X"
+      } ],
+      "available_markets" : [ "AR", "AU", "AT", "BE", "BO", "BR", "BG", "CA", "CL", "CO", "CR", "CY", "CZ", "DK", "DO", "DE", "EC", "EE", "SV", "FI", "FR", "GR", "GT", "HN", "HK", "HU", "IS", "IE", "IT", "LV", "LT", "LU", "MY", "MT", "MX", "NL", "NZ", "NI", "NO", "PA", "PY", "PE", "PH", "PL", "PT", "SG", "SK", "ES", "SE", "CH", "TW", "TR", "UY", "US", "GB", "AD", "LI", "MC", "ID", "JP", "TH", "VN", "RO", "IL", "ZA", "SA", "AE", "BH", "QA", "OM", "KW", "EG", "MA", "DZ", "TN", "LB", "JO", "PS", "IN", "BY", "KZ", "MD", "UA", "AL", "BA", "HR", "ME", "MK", "RS", "SI", "KR", "BD", "PK", "LK", "GH", "KE", "NG", "TZ", "UG", "AG", "AM", "BS", "BB", "BZ", "BT", "BW", "BF", "CV", "CW", "DM", "FJ", "GM", "GE", "GD", "GW", "GY", "HT", "JM", "KI", "LS", "LR", "MW", "MV", "ML", "MH", "FM", "NA", "NR", "NE", "PW", "PG", "WS", "SM", "ST", "SN", "SC", "SL", "SB", "KN", "LC", "VC", "SR", "TL", "TO", "TT", "TV", "VU", "AZ", "BN", "BI", "KH", "CM", "TD", "KM", "GQ", "SZ", "GA", "GN", "KG", "LA", "MO", "MR", "MN", "NP", "RW", "TG", "UZ", "ZW", "BJ", "MG", "MU", "MZ", "AO", "CI", "DJ", "ZM", "CD", "CG", "IQ", "LY", "TJ", "VE", "ET", "XK" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/5Welfv6PlfPJqQcrSmb44F"
+      },
+      "href" : "https://api.spotify.com/v1/albums/5Welfv6PlfPJqQcrSmb44F",
+      "id" : "5Welfv6PlfPJqQcrSmb44F",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b273ed8f22bc6ed33149a229599e",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e02ed8f22bc6ed33149a229599e",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d00004851ed8f22bc6ed33149a229599e",
+        "width" : 64
+      } ],
+      "name" : "L.I.T (Lost In Translation)",
+      "release_date" : "2023-11-10",
+      "release_date_precision" : "day",
+      "total_tracks" : 5,
+      "type" : "album",
+      "uri" : "spotify:album:5Welfv6PlfPJqQcrSmb44F"
+    }, {
+      "album_type" : "album",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/3WrFJ7ztbogyGnTHbHJFl2"
+        },
+        "href" : "https://api.spotify.com/v1/artists/3WrFJ7ztbogyGnTHbHJFl2",
+        "id" : "3WrFJ7ztbogyGnTHbHJFl2",
+        "name" : "The Beatles",
+        "type" : "artist",
+        "uri" : "spotify:artist:3WrFJ7ztbogyGnTHbHJFl2"
+      } ],
+      "available_markets" : [ "AR", "AU", "AT", "BE", "BO", "BR", "BG", "CA", "CL", "CO", "CR", "CY", "CZ", "DK", "DO", "DE", "EC", "EE", "SV", "FI", "FR", "GR", "GT", "HN", "HK", "HU", "IS", "IE", "IT", "LV", "LT", "LU", "MY", "MT", "MX", "NL", "NZ", "NI", "NO", "PA", "PY", "PE", "PH", "PL", "PT", "SG", "SK", "ES", "SE", "CH", "TW", "TR", "UY", "US", "GB", "AD", "LI", "MC", "ID", "JP", "TH", "VN", "RO", "IL", "ZA", "SA", "AE", "BH", "QA", "OM", "KW", "EG", "MA", "DZ", "TN", "LB", "JO", "PS", "IN", "KZ", "MD", "UA", "AL", "BA", "HR", "ME", "MK", "RS", "SI", "KR", "BD", "PK", "LK", "GH", "KE", "NG", "TZ", "UG", "AG", "AM", "BS", "BB", "BZ", "BT", "BW", "BF", "CV", "CW", "DM", "FJ", "GM", "GE", "GD", "GW", "GY", "HT", "JM", "KI", "LS", "LR", "MW", "MV", "ML", "MH", "FM", "NA", "NR", "NE", "PW", "PG", "WS", "SM", "ST", "SN", "SC", "SL", "SB", "KN", "LC", "VC", "SR", "TL", "TO", "TT", "TV", "VU", "AZ", "BN", "BI", "KH", "CM", "TD", "KM", "GQ", "SZ", "GA", "GN", "KG", "LA", "MO", "MR", "MN", "NP", "RW", "TG", "UZ", "ZW", "BJ", "MG", "MU", "MZ", "AO", "CI", "DJ", "ZM", "CD", "CG", "IQ", "LY", "TJ", "VE", "ET", "XK" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/2AlPRfYeskAMxhJS00xjeP"
+      },
+      "href" : "https://api.spotify.com/v1/albums/2AlPRfYeskAMxhJS00xjeP",
+      "id" : "2AlPRfYeskAMxhJS00xjeP",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b2732ad20d4688bdc999413ece39",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e022ad20d4688bdc999413ece39",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d000048512ad20d4688bdc999413ece39",
+        "width" : 64
+      } ],
+      "name" : "The Beatles 1967 – 1970 (2023 Edition)",
+      "release_date" : "2023-11-10",
+      "release_date_precision" : "day",
+      "total_tracks" : 37,
+      "type" : "album",
+      "uri" : "spotify:album:2AlPRfYeskAMxhJS00xjeP"
+    }, {
+      "album_type" : "album",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/3WrFJ7ztbogyGnTHbHJFl2"
+        },
+        "href" : "https://api.spotify.com/v1/artists/3WrFJ7ztbogyGnTHbHJFl2",
+        "id" : "3WrFJ7ztbogyGnTHbHJFl2",
+        "name" : "The Beatles",
+        "type" : "artist",
+        "uri" : "spotify:artist:3WrFJ7ztbogyGnTHbHJFl2"
+      } ],
+      "available_markets" : [ "AR", "AU", "AT", "BE", "BO", "BR", "BG", "CA", "CL", "CO", "CR", "CY", "CZ", "DK", "DO", "DE", "EC", "EE", "SV", "FI", "FR", "GR", "GT", "HN", "HK", "HU", "IS", "IE", "IT", "LV", "LT", "LU", "MY", "MT", "MX", "NL", "NZ", "NI", "NO", "PA", "PY", "PE", "PH", "PL", "PT", "SG", "SK", "ES", "SE", "CH", "TW", "TR", "UY", "US", "GB", "AD", "LI", "MC", "ID", "JP", "TH", "VN", "RO", "IL", "ZA", "SA", "AE", "BH", "QA", "OM", "KW", "EG", "MA", "DZ", "TN", "LB", "JO", "PS", "IN", "KZ", "MD", "UA", "AL", "BA", "HR", "ME", "MK", "RS", "SI", "KR", "BD", "PK", "LK", "GH", "KE", "NG", "TZ", "UG", "AG", "AM", "BS", "BB", "BZ", "BT", "BW", "BF", "CV", "CW", "DM", "FJ", "GM", "GE", "GD", "GW", "GY", "HT", "JM", "KI", "LS", "LR", "MW", "MV", "ML", "MH", "FM", "NA", "NR", "NE", "PW", "PG", "WS", "SM", "ST", "SN", "SC", "SL", "SB", "KN", "LC", "VC", "SR", "TL", "TO", "TT", "TV", "VU", "AZ", "BN", "BI", "KH", "CM", "TD", "KM", "GQ", "SZ", "GA", "GN", "KG", "LA", "MO", "MR", "MN", "NP", "RW", "TG", "UZ", "ZW", "BJ", "MG", "MU", "MZ", "AO", "CI", "DJ", "ZM", "CD", "CG", "IQ", "LY", "TJ", "VE", "ET", "XK" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/39Ti6Be9Ak2d6YbxlQo0Ba"
+      },
+      "href" : "https://api.spotify.com/v1/albums/39Ti6Be9Ak2d6YbxlQo0Ba",
+      "id" : "39Ti6Be9Ak2d6YbxlQo0Ba",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b2734a4c7445df9b3719a60eb53b",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e024a4c7445df9b3719a60eb53b",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d000048514a4c7445df9b3719a60eb53b",
+        "width" : 64
+      } ],
+      "name" : "The Beatles 1962 – 1966 (2023 Edition)",
+      "release_date" : "2023-11-10",
+      "release_date_precision" : "day",
+      "total_tracks" : 38,
+      "type" : "album",
+      "uri" : "spotify:album:39Ti6Be9Ak2d6YbxlQo0Ba"
+    }, {
+      "album_type" : "album",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/4VqlewwKZJoIcA88PYHUDd"
+        },
+        "href" : "https://api.spotify.com/v1/artists/4VqlewwKZJoIcA88PYHUDd",
+        "id" : "4VqlewwKZJoIcA88PYHUDd",
+        "name" : "Baby Queen",
+        "type" : "artist",
+        "uri" : "spotify:artist:4VqlewwKZJoIcA88PYHUDd"
+      } ],
+      "available_markets" : [ "AR", "AU", "AT", "BE", "BO", "BR", "BG", "CA", "CL", "CO", "CR", "CY", "CZ", "DK", "DO", "DE", "EC", "EE", "SV", "FI", "FR", "GR", "GT", "HN", "HK", "HU", "IS", "IE", "IT", "LV", "LT", "LU", "MY", "MT", "MX", "NL", "NZ", "NI", "NO", "PA", "PY", "PE", "PH", "PL", "PT", "SG", "SK", "ES", "SE", "CH", "TW", "TR", "UY", "US", "GB", "AD", "LI", "MC", "ID", "JP", "TH", "VN", "RO", "IL", "ZA", "SA", "AE", "BH", "QA", "OM", "KW", "EG", "MA", "DZ", "TN", "LB", "JO", "PS", "IN", "KZ", "MD", "UA", "AL", "BA", "HR", "ME", "MK", "RS", "SI", "KR", "BD", "PK", "LK", "GH", "KE", "NG", "TZ", "UG", "AG", "AM", "BS", "BB", "BZ", "BT", "BW", "BF", "CV", "CW", "DM", "FJ", "GM", "GE", "GD", "GW", "GY", "HT", "JM", "KI", "LS", "LR", "MW", "MV", "ML", "MH", "FM", "NA", "NR", "NE", "PW", "PG", "WS", "SM", "ST", "SN", "SC", "SL", "SB", "KN", "LC", "VC", "SR", "TL", "TO", "TT", "TV", "VU", "AZ", "BN", "BI", "KH", "CM", "TD", "KM", "GQ", "SZ", "GA", "GN", "KG", "LA", "MO", "MR", "MN", "NP", "RW", "TG", "UZ", "ZW", "BJ", "MG", "MU", "MZ", "AO", "CI", "DJ", "ZM", "CD", "CG", "IQ", "LY", "TJ", "VE", "ET", "XK" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/71mcDUoyViKC1i3kmAvJiI"
+      },
+      "href" : "https://api.spotify.com/v1/albums/71mcDUoyViKC1i3kmAvJiI",
+      "id" : "71mcDUoyViKC1i3kmAvJiI",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b27319a0d33a6007a0affefff3af",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e0219a0d33a6007a0affefff3af",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d0000485119a0d33a6007a0affefff3af",
+        "width" : 64
+      } ],
+      "name" : "Quarter Life Crisis (Deluxe)",
+      "release_date" : "2023-11-10",
+      "release_date_precision" : "day",
+      "total_tracks" : 21,
+      "type" : "album",
+      "uri" : "spotify:album:71mcDUoyViKC1i3kmAvJiI"
+    }, {
+      "album_type" : "single",
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/3WrFJ7ztbogyGnTHbHJFl2"
+        },
+        "href" : "https://api.spotify.com/v1/artists/3WrFJ7ztbogyGnTHbHJFl2",
+        "id" : "3WrFJ7ztbogyGnTHbHJFl2",
+        "name" : "The Beatles",
+        "type" : "artist",
+        "uri" : "spotify:artist:3WrFJ7ztbogyGnTHbHJFl2"
+      } ],
+      "available_markets" : [ "AR", "AU", "AT", "BE", "BO", "BR", "BG", "CA", "CL", "CO", "CR", "CY", "CZ", "DK", "DO", "DE", "EC", "EE", "SV", "FI", "FR", "GR", "GT", "HN", "HK", "HU", "IS", "IE", "IT", "LV", "LT", "LU", "MY", "MT", "MX", "NL", "NZ", "NI", "NO", "PA", "PY", "PE", "PH", "PL", "PT", "SG", "SK", "ES", "SE", "CH", "TW", "TR", "UY", "US", "GB", "AD", "LI", "MC", "ID", "JP", "TH", "VN", "RO", "IL", "ZA", "SA", "AE", "BH", "QA", "OM", "KW", "EG", "MA", "DZ", "TN", "LB", "JO", "PS", "IN", "KZ", "MD", "UA", "AL", "BA", "HR", "ME", "MK", "RS", "SI", "KR", "BD", "PK", "LK", "GH", "KE", "NG", "TZ", "UG", "AG", "AM", "BS", "BB", "BZ", "BT", "BW", "BF", "CV", "CW", "DM", "FJ", "GM", "GE", "GD", "GW", "GY", "HT", "JM", "KI", "LS", "LR", "MW", "MV", "ML", "MH", "FM", "NA", "NR", "NE", "PW", "PG", "WS", "SM", "ST", "SN", "SC", "SL", "SB", "KN", "LC", "VC", "SR", "TL", "TO", "TT", "TV", "VU", "AZ", "BN", "BI", "KH", "CM", "TD", "KM", "GQ", "SZ", "GA", "GN", "KG", "LA", "MO", "MR", "MN", "NP", "RW", "TG", "UZ", "ZW", "BJ", "MG", "MU", "MZ", "AO", "CI", "DJ", "ZM", "CD", "CG", "IQ", "LY", "TJ", "VE", "ET", "XK" ],
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/album/2qQP2NgOoH6HqknnbpJmIk"
+      },
+      "href" : "https://api.spotify.com/v1/albums/2qQP2NgOoH6HqknnbpJmIk",
+      "id" : "2qQP2NgOoH6HqknnbpJmIk",
+      "images" : [ {
+        "height" : 640,
+        "url" : "https://i.scdn.co/image/ab67616d0000b273ccf24b5f25d58914b1321357",
+        "width" : 640
+      }, {
+        "height" : 300,
+        "url" : "https://i.scdn.co/image/ab67616d00001e02ccf24b5f25d58914b1321357",
+        "width" : 300
+      }, {
+        "height" : 64,
+        "url" : "https://i.scdn.co/image/ab67616d00004851ccf24b5f25d58914b1321357",
+        "width" : 64
+      } ],
+      "name" : "Now And Then",
+      "release_date" : "2023-11-02",
+      "release_date_precision" : "day",
+      "total_tracks" : 2,
+      "type" : "album",
+      "uri" : "spotify:album:2qQP2NgOoH6HqknnbpJmIk"
+    } ],
+    "limit" : 20,
+    "next" : "https://api.spotify.com/v1/browse/new-releases?country=GB&offset=20&limit=20",
+    "offset" : 0,
+    "previous" : null,
+    "total" : 100
+  }
+}

--- a/src/test/java/com/example/spotifyexplorer/unit/NewAlbumServiceUnitTests.java
+++ b/src/test/java/com/example/spotifyexplorer/unit/NewAlbumServiceUnitTests.java
@@ -1,0 +1,6 @@
+package com.example.spotifyexplorer.unit;
+
+public class NewAlbumServiceUnitTests {
+
+
+}


### PR DESCRIPTION
This PR adds a unit test for the service account as well as separating the concerns for service layer and client layer. The client layer now calls the Spotify API.